### PR TITLE
Enhance Group Invite Flow with Secure Token Handling and Owner Display

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+      },
+      {
+        protocol: 'https',
+        hostname: '5so7pcxs20ktkjkb.public.blob.vercel-storage.com',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(main)/dashboard/groups/GroupsClient.tsx
+++ b/src/app/(main)/dashboard/groups/GroupsClient.tsx
@@ -22,6 +22,14 @@ interface GroupsClientProps {
     name: string;
     description?: string | null;
     createdAt: Date;
+    ownerId: string;
+    owner: {
+      id: string;
+      firstName: string;
+      image: string | null;
+      nickname: string | null;
+      email: string;
+    };
     groupMembers: {
       user: {
         id: string;
@@ -91,11 +99,20 @@ export default function GroupsClient({ groups }: GroupsClientProps) {
                       image: user.image,
                       status: 'member' as const,
                     })),
-                    ...group.groupInvites.map((invite) => ({
-                      email: invite.email,
-                      status: invite.status as 'pending',
-                    })),
+                    ...group.groupInvites
+                      .filter((invite) => invite.status === 'pending')
+                      .map((invite) => ({
+                        email: invite.email,
+                        status: invite.status as 'pending',
+                      })),
                   ]}
+                  owner={{
+                    id: group.ownerId,
+                    email: group.owner.email,
+                    firstName: group.owner.firstName,
+                    nickname: group.owner.nickname,
+                    image: group.owner.image,
+                  }}
                 />
               </CardContent>
             </Card>

--- a/src/app/(main)/dashboard/groups/GroupsPage.tsx
+++ b/src/app/(main)/dashboard/groups/GroupsPage.tsx
@@ -5,27 +5,18 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import prisma from '@/lib/prisma';
+import { getUserGroups } from '@/lib/queries/getUserGroups';
 import { getSession } from '@/utils/sessions';
 import GroupsClient from './GroupsClient';
 
 export default async function GroupsPage() {
   const session = await getSession();
 
-  const groups = await prisma.group.findMany({
-    where: { ownerId: session?.user?.id },
-    orderBy: { createdAt: 'desc' },
-    include: {
-      groupMembers: {
-        include: { user: true },
-      },
-      groupInvites: true,
-    },
-  });
+  const groups = await getUserGroups(session?.user?.id as string);
 
   return (
     <div className="flex items-center justify-center px-4 py-12">
-      <Card className="w-full max-w-6xl">
+      <Card className="w-full max-w-7xl">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl font-bold">Your Groups</CardTitle>
           <CardDescription>

--- a/src/app/(main)/dashboard/groups/_components/ViewGroupMembersModal.tsx
+++ b/src/app/(main)/dashboard/groups/_components/ViewGroupMembersModal.tsx
@@ -25,10 +25,18 @@ interface Member {
 
 interface ViewMembersModalProps {
   members: Member[];
+  owner?: {
+    id: string;
+    email: string;
+    firstName?: string;
+    nickname?: string | null;
+    image?: string | null;
+  };
 }
 
 export default function ViewGroupMembersModal({
   members,
+  owner,
 }: ViewMembersModalProps) {
   const { type, isOpen, close } = useGroupModals();
 
@@ -45,12 +53,33 @@ export default function ViewGroupMembersModal({
         </ResponsiveModalHeader>
 
         <div className="space-y-4 max-h-[50vh] overflow-y-auto pr-2">
+          {owner && (
+            <div className="mb-4 mt-4 md:mt-2">
+              <div className="flex items-center justify-between text-sm">
+                <div className="flex items-center gap-2">
+                  <Image
+                    src={owner.image ?? '/placeholder-avatar.jpg'}
+                    alt={owner.nickname ?? owner.firstName ?? 'Owner'}
+                    width={28}
+                    height={28}
+                    className="rounded-full object-cover w-7 h-7"
+                  />
+                  <span>
+                    {owner.nickname || owner.firstName || owner.email}
+                  </span>
+                </div>
+                <Badge className="whitespace-nowrap">Owner</Badge>
+              </div>
+              <Separator className="my-4" />
+            </div>
+          )}
+
           {members.length === 0 ? (
             <p className="text-sm text-muted-foreground">No members yet.</p>
           ) : (
             members.map((member) => (
               <div
-                key={member.email}
+                key={member.id ?? `${member.email}-${member.status}`}
                 className="flex items-center justify-between text-sm"
               >
                 <div className="flex items-center gap-2">

--- a/src/app/(main)/dashboard/groups/actions.ts
+++ b/src/app/(main)/dashboard/groups/actions.ts
@@ -87,6 +87,10 @@ export async function deleteGroupAction(groupId: string) {
       return { error: 'You are not authorized to delete this group.' };
     }
 
+    await prisma.groupMember.deleteMany({
+      where: { groupId },
+    });
+
     await prisma.groupInvite.deleteMany({
       where: { groupId },
     });

--- a/src/app/(main)/dashboard/settings/AccountSettingsPage.tsx
+++ b/src/app/(main)/dashboard/settings/AccountSettingsPage.tsx
@@ -19,7 +19,7 @@ export default async function AccountSettingsPage() {
 
   return (
     <div className="flex items-center justify-center px-4 py-12">
-      <Card className="w-full max-w-3xl">
+      <Card className="w-full max-w-7xl">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl font-bold">Account Settings</CardTitle>
           <CardDescription>

--- a/src/app/(main)/invite/accept/AcceptGroupInvitePage.tsx
+++ b/src/app/(main)/invite/accept/AcceptGroupInvitePage.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+import { acceptGroupInvite } from './actions';
+
+export default function AcceptGroupInvitePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+
+    if (!token) {
+      toast.error('Invite token is missing.');
+      router.push('/');
+      return;
+    }
+
+    acceptGroupInvite(token).then((res) => {
+      if (res?.error) {
+        toast.error(res.error);
+      } else {
+        toast.success('You have joined the group!');
+        router.push(res.redirectTo || '/dashboard/groups');
+      }
+    });
+  }, [searchParams, router]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center">
+      <p className="text-muted-foreground">Accepting your invitation...</p>
+    </div>
+  );
+}

--- a/src/app/(main)/invite/accept/actions.ts
+++ b/src/app/(main)/invite/accept/actions.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import prisma from '@/lib/prisma';
+import { getSession } from '@/utils/sessions';
+import { verifyGroupInviteToken } from '@/utils/tokens';
+import { revalidatePath } from 'next/cache';
+
+export async function acceptGroupInvite(token: string) {
+  const session = await getSession();
+
+  if (!session || !session.user?.email) {
+    return { error: "You need to be logged in to accept an invite." };
+  }
+
+  const { invite, error } = await verifyGroupInviteToken(token);
+
+  if (error || !invite) {
+    return { error };
+  }
+
+  if (session.user.email !== invite.email) {
+    return { error: "This invite was not sent to your account." };
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!user) {
+    return { error: "You need to create an account before accepting the invite." };
+  }
+
+  await prisma.groupMember.create({
+    data: {
+      userId: user.id,
+      groupId: invite.groupId,
+    },
+  });
+
+  await prisma.groupInvite.update({
+    where: { token },
+    data: { status: "accepted" },
+  });
+
+  revalidatePath('/dashboard/groups');
+
+  return { success: true, redirectTo: '/dashboard/groups' };
+}

--- a/src/app/(main)/invite/accept/page.tsx
+++ b/src/app/(main)/invite/accept/page.tsx
@@ -1,0 +1,16 @@
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { Metadata } from 'next';
+import { Suspense } from 'react';
+import AcceptGroupInvitePage from './AcceptGroupInvitePage';
+
+export const metadata: Metadata = {
+  title: 'Accept Invite',
+};
+
+export default function Page() {
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      <AcceptGroupInvitePage />
+    </Suspense>
+  );
+}

--- a/src/lib/queries/getUserGroups.ts
+++ b/src/lib/queries/getUserGroups.ts
@@ -1,0 +1,24 @@
+import prisma from '@/lib/prisma';
+
+export async function getUserGroups(userId: string) {
+  if (!userId) return [];
+
+  const groups = await prisma.group.findMany({
+    where: {
+      OR: [
+        { ownerId: userId },
+        { groupMembers: { some: { userId } } },
+      ],
+    },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      owner: true,
+      groupMembers: {
+        include: { user: true },
+      },
+      groupInvites: true,
+    },
+  });
+
+  return groups;
+}

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -170,3 +170,32 @@ export const deleteResetPasswordToken = async (token: string) => {
     console.error("Error deleting reset password token:", error);
   }
 };
+
+export const generateGroupInviteToken = async (email: string, groupId: string) => {
+  const token = crypto.randomBytes(32).toString("hex");
+
+  await prisma.groupInvite.create({
+    data: {
+      email,
+      token,
+      groupId,
+      status: 'pending',
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+    },
+  });
+
+  return token;
+};
+
+export const verifyGroupInviteToken = async (token: string) => {
+  const invite = await prisma.groupInvite.findUnique({
+    where: { token },
+    include: { group: true },
+  });
+
+  if (!invite || invite.expiresAt < new Date() || invite.status !== 'pending') {
+    return { error: 'Invalid or expired invitation link.' };
+  }
+
+  return { invite, error: null };
+};


### PR DESCRIPTION
### ✨ Summary

This PR improves the group invite system with the following enhancements:

- ✅ Added secure verification to ensure only the invited user can accept the group invite.
- ✅ Ensured invite tokens are validated with expiry and pending status.
- ✅ Updated `acceptGroupInvite` server action to validate session and match the user's email to the invite.
- ✅ Prevented users from inviting themselves.
- ✅ Displayed group owner separately in the member modal.
- ✅ Filtered out accepted invites from the pending list in the UI.
- ✅ Cleaned up group deletion logic to also remove members and invites.
- ✅ Added `owner` field to `getUserGroups` query and ensured it’s passed to the frontend.

### 🧪 Testing

- Invites cannot be accepted if:
  - Not logged in.
  - The logged-in user's email doesn’t match the invite email.
  - The token is expired or already used.
- Group owner is correctly displayed.
- Members list excludes accepted invites.
- Invite flow shows appropriate toast messages and redirects.